### PR TITLE
Prevent duplicate code in 'bucket' package

### DIFF
--- a/api/src/main/java/com/bivashy/auth/api/bucket/AuthenticationStepContextFactoryBucket.java
+++ b/api/src/main/java/com/bivashy/auth/api/bucket/AuthenticationStepContextFactoryBucket.java
@@ -11,6 +11,7 @@ import com.bivashy.auth.api.factory.AuthenticationStepContextFactory;
 import com.bivashy.auth.api.step.AuthenticationStepContext;
 
 public interface AuthenticationStepContextFactoryBucket extends Bucket<AuthenticationStepContextFactoryWrapper> {
+
     @Deprecated
     default Map<String, AuthenticationStepContextFactory> getMap() {
         return stream().collect(Collectors.toMap(AuthenticationStepContextFactoryWrapper::getIdentifier, Function.identity()));
@@ -24,24 +25,24 @@ public interface AuthenticationStepContextFactoryBucket extends Bucket<Authentic
 
     @Deprecated
     default AuthenticationStepContextFactory remove(String key) {
-        Optional<AuthenticationStepContextFactoryWrapper> factoryOptional = findFirst(wrapper -> wrapper.getIdentifier().equals(key));
+        Optional<AuthenticationStepContextFactoryWrapper> factoryOptional = findFirstByValue(AuthenticationStepContextFactoryWrapper::getIdentifier, key);
         factoryOptional.ifPresent(factory -> modifiable().removeIf(wrapper -> factory.getIdentifier().equals(wrapper.getIdentifier())));
         return factoryOptional.orElse(null);
     }
 
     @Deprecated
     default AuthenticationStepContextFactory get(String key) {
-        return findFirst(wrapper -> wrapper.getIdentifier().equals(key)).orElse(null);
+        return findFirstByValue(AuthenticationStepContextFactoryWrapper::getIdentifier, key).orElse(null);
     }
 
     @Deprecated
     default AuthenticationStepContextFactory getOrDefault(String key, AuthenticationStepContextFactory def) {
-        return findFirst(wrapper -> wrapper.getIdentifier().equals(key)).map(wrapper -> (AuthenticationStepContextFactory) wrapper).orElse(def);
+        return findFirstByValue(AuthenticationStepContextFactoryWrapper::getIdentifier, key).map(wrapper -> (AuthenticationStepContextFactory) wrapper).orElse(def);
     }
 
     @Deprecated
     default boolean containsKey(String key) {
-        return has(wrapper -> wrapper.getIdentifier().equals(key));
+        return hasByValue(AuthenticationStepContextFactoryWrapper::getIdentifier, key);
     }
 
     AuthenticationStepContext createContext(Account account);
@@ -49,6 +50,7 @@ public interface AuthenticationStepContextFactoryBucket extends Bucket<Authentic
     AuthenticationStepContext createContext(String stepName, Account account);
 
     interface AuthenticationStepContextFactoryWrapper extends AuthenticationStepContextFactory {
+
         static AuthenticationStepContextFactoryWrapper of(String identifier, AuthenticationStepContextFactory factory) {
             return new AuthenticationStepContextFactoryWrapper() {
                 @Override
@@ -64,5 +66,7 @@ public interface AuthenticationStepContextFactoryBucket extends Bucket<Authentic
         }
 
         String getIdentifier();
+
     }
+
 }

--- a/api/src/main/java/com/bivashy/auth/api/bucket/AuthenticationStepFactoryBucket.java
+++ b/api/src/main/java/com/bivashy/auth/api/bucket/AuthenticationStepFactoryBucket.java
@@ -1,20 +1,25 @@
 package com.bivashy.auth.api.bucket;
 
-import java.util.Iterator;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import java.util.function.Predicate;
 
 import com.bivashy.auth.api.factory.AuthenticationStepFactory;
 
-public interface AuthenticationStepFactoryBucket {
-    List<AuthenticationStepFactory> getList();
+public interface AuthenticationStepFactoryBucket extends Bucket<AuthenticationStepFactory> {
 
-    void add(AuthenticationStepFactory authenticationStepCreator);
+    @Deprecated
+    default List<AuthenticationStepFactory> getList() {
+        return new ArrayList<>(getUnmodifiableRaw());
+    }
 
-    void remove(AuthenticationStepFactory authenticationStepCreator);
+    @Deprecated
+    default void add(AuthenticationStepFactory authenticationStepCreator) {
+        modifiable().add(authenticationStepCreator);
+    }
 
-    Iterator<AuthenticationStepFactory> iterator();
+    @Deprecated
+    default void remove(AuthenticationStepFactory authenticationStepCreator) {
+        modifiable().remove(authenticationStepCreator);
+    }
 
-    Optional<AuthenticationStepFactory> findFirst(Predicate<AuthenticationStepFactory> filter);
 }

--- a/api/src/main/java/com/bivashy/auth/api/bucket/AuthenticationTaskBucket.java
+++ b/api/src/main/java/com/bivashy/auth/api/bucket/AuthenticationTaskBucket.java
@@ -1,20 +1,25 @@
 package com.bivashy.auth.api.bucket;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import com.bivashy.auth.api.model.AuthenticationTask;
 
 public interface AuthenticationTaskBucket extends Bucket<AuthenticationTask> {
+
     @Deprecated
-    default void addTask(AuthenticationTask task){
+    default void addTask(AuthenticationTask task) {
         modifiable().add(task);
     }
 
     @Deprecated
-    default void removeTask(AuthenticationTask task){
+    default void removeTask(AuthenticationTask task) {
         modifiable().remove(task);
     }
 
     @Deprecated
-    List<AuthenticationTask> getTasks();
+    default List<AuthenticationTask> getTasks() {
+        return new ArrayList<>(getUnmodifiableRaw());
+    }
+
 }

--- a/api/src/main/java/com/bivashy/auth/api/bucket/AuthenticationTaskBucket.java
+++ b/api/src/main/java/com/bivashy/auth/api/bucket/AuthenticationTaskBucket.java
@@ -4,10 +4,17 @@ import java.util.List;
 
 import com.bivashy.auth.api.model.AuthenticationTask;
 
-public interface AuthenticationTaskBucket {
-    void addTask(AuthenticationTask task);
+public interface AuthenticationTaskBucket extends Bucket<AuthenticationTask> {
+    @Deprecated
+    default void addTask(AuthenticationTask task){
+        modifiable().add(task);
+    }
 
-    void removeTask(AuthenticationTask task);
+    @Deprecated
+    default void removeTask(AuthenticationTask task){
+        modifiable().remove(task);
+    }
 
+    @Deprecated
     List<AuthenticationTask> getTasks();
 }

--- a/api/src/main/java/com/bivashy/auth/api/bucket/Bucket.java
+++ b/api/src/main/java/com/bivashy/auth/api/bucket/Bucket.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public interface Bucket<T> {
+
     Collection<T> getUnmodifiableRaw();
 
     Stream<T> stream();
@@ -36,7 +37,16 @@ public interface Bucket<T> {
         return findFirst(predicate).isPresent();
     }
 
+    default <R> boolean hasBy(Function<T, R> function, Predicate<R> predicate) {
+        return findFirstBy(function, predicate).isPresent();
+    }
+
+    default <R> boolean hasByValue(Function<T, R> function, R value) {
+        return findFirstByValue(function, value).isPresent();
+    }
+
     default Stream<T> filter(Predicate<T> predicate) {
         return getUnmodifiableRaw().stream().filter(predicate);
     }
+
 }

--- a/api/src/main/java/com/bivashy/auth/api/bucket/Bucket.java
+++ b/api/src/main/java/com/bivashy/auth/api/bucket/Bucket.java
@@ -2,7 +2,9 @@ package com.bivashy.auth.api.bucket;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -16,6 +18,14 @@ public interface Bucket<T> {
 
     default Optional<T> findFirst(Predicate<T> predicate) {
         return filter(predicate).findFirst();
+    }
+
+    default <R> Optional<T> findFirstBy(Function<T, R> function, Predicate<R> predicate) {
+        return findFirst(element -> predicate.test(function.apply(element)));
+    }
+
+    default <R> Optional<T> findFirstByValue(Function<T, R> function, R value) {
+        return findFirstBy(function, r -> Objects.equals(r, value));
     }
 
     default List<T> find(Predicate<T> predicate) {

--- a/api/src/main/java/com/bivashy/auth/api/bucket/Bucket.java
+++ b/api/src/main/java/com/bivashy/auth/api/bucket/Bucket.java
@@ -1,0 +1,32 @@
+package com.bivashy.auth.api.bucket;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public interface Bucket<T> {
+    Collection<T> getUnmodifiableRaw();
+
+    Stream<T> stream();
+
+    ModifiableBucket<T> modifiable();
+
+    default Optional<T> findFirst(Predicate<T> predicate) {
+        return filter(predicate).findFirst();
+    }
+
+    default List<T> find(Predicate<T> predicate) {
+        return filter(predicate).collect(Collectors.toList());
+    }
+
+    default boolean has(Predicate<T> predicate) {
+        return findFirst(predicate).isPresent();
+    }
+
+    default Stream<T> filter(Predicate<T> predicate) {
+        return getUnmodifiableRaw().stream().filter(predicate);
+    }
+}

--- a/api/src/main/java/com/bivashy/auth/api/bucket/CryptoProviderBucket.java
+++ b/api/src/main/java/com/bivashy/auth/api/bucket/CryptoProviderBucket.java
@@ -4,8 +4,16 @@ import java.util.Optional;
 
 import com.bivashy.auth.api.crypto.CryptoProvider;
 
-public interface CryptoProviderBucket {
-    Optional<CryptoProvider> findCryptoProvider(String identifier);
+public interface CryptoProviderBucket extends Bucket<CryptoProvider> {
 
-    void addCryptoProvider(CryptoProvider cryptoProvider);
+    @Deprecated
+    default Optional<CryptoProvider> findCryptoProvider(String identifier) {
+        return findFirstByValue(CryptoProvider::getIdentifier, identifier);
+    }
+
+    @Deprecated
+    default void addCryptoProvider(CryptoProvider cryptoProvider) {
+        modifiable().add(cryptoProvider);
+    }
+
 }

--- a/api/src/main/java/com/bivashy/auth/api/bucket/LinkAuthenticationBucket.java
+++ b/api/src/main/java/com/bivashy/auth/api/bucket/LinkAuthenticationBucket.java
@@ -7,22 +7,58 @@ import java.util.function.Predicate;
 import com.bivashy.auth.api.link.LinkType;
 import com.bivashy.auth.api.link.user.LinkUser;
 
-public interface LinkAuthenticationBucket<T extends LinkUser> {
-    boolean hasLinkUser(Predicate<T> filter);
+public interface LinkAuthenticationBucket<T extends LinkUser> extends Bucket<T> {
 
-    boolean hasLinkUser(String id, LinkType linkType);
+    default Predicate<T> createFilter(String accountId, LinkType linkType) {
+        return linkUser -> linkUser.getAccount().getPlayerId().equals(accountId) && linkUser.getLinkType().equals(linkType);
+    }
 
-    void addLinkUser(T linkUser);
+    default Optional<T> find(String id, LinkType linkType) {
+        return findFirst(createFilter(id, linkType));
+    }
 
-    void removeLinkUsers(Predicate<T> filter);
+    @Deprecated
+    default boolean hasLinkUser(Predicate<T> filter) {
+        return has(filter);
+    }
 
-    void removeLinkUser(String id, LinkType linkType);
+    @Deprecated
+    default boolean hasLinkUser(String id, LinkType linkType) {
+        return has(createFilter(id, linkType));
+    }
 
-    void removeLinkUser(T linkUser);
+    @Deprecated
+    default void addLinkUser(T linkUser) {
+        modifiable().add(linkUser);
+    }
 
-    Optional<T> findFirstLinkUser(Predicate<T> filter);
+    default void removeLinkUsers(Predicate<T> filter) {
+        modifiable().removeIf(filter);
+    }
 
-    List<T> getLinkUsers(Predicate<T> filter);
+    @Deprecated
+    default void removeLinkUser(String id, LinkType linkType) {
+        modifiable().removeIf(createFilter(id, linkType));
+    }
 
-    T getLinkUser(String id, LinkType linkType);
+    @Deprecated
+    default void removeLinkUser(T linkUser) {
+        modifiable().remove(linkUser);
+    }
+
+    @Deprecated
+    default Optional<T> findFirstLinkUser(Predicate<T> filter) {
+        return findFirst(filter);
+    }
+
+    @Deprecated
+    default List<T> getLinkUsers(Predicate<T> filter) {
+        return find(filter);
+    }
+
+    @Deprecated
+    default T getLinkUser(String id, LinkType linkType) {
+        return findFirst(createFilter(id, linkType)).orElse(null);
+    }
+
 }

--- a/api/src/main/java/com/bivashy/auth/api/bucket/LinkConfirmationBucket.java
+++ b/api/src/main/java/com/bivashy/auth/api/bucket/LinkConfirmationBucket.java
@@ -1,19 +1,24 @@
 package com.bivashy.auth.api.bucket;
 
 import java.util.Collection;
-import java.util.Optional;
-import java.util.function.Predicate;
 
 import com.bivashy.auth.api.link.user.confirmation.LinkConfirmationUser;
 
-public interface LinkConfirmationBucket {
-    Collection<LinkConfirmationUser> getConfirmationUsers();
+public interface LinkConfirmationBucket extends Bucket<LinkConfirmationUser> {
 
-    void addLinkConfirmation(LinkConfirmationUser user);
-
-    void removeLinkConfirmation(LinkConfirmationUser user);
-
-    default Optional<LinkConfirmationUser> findFirst(Predicate<LinkConfirmationUser> filter) {
-        return getConfirmationUsers().stream().filter(filter).findFirst();
+    @Deprecated
+    default Collection<LinkConfirmationUser> getConfirmationUsers() {
+        return getUnmodifiableRaw();
     }
+
+    @Deprecated
+    default void addLinkConfirmation(LinkConfirmationUser user) {
+        modifiable().add(user);
+    }
+
+    @Deprecated
+    default void removeLinkConfirmation(LinkConfirmationUser user) {
+        modifiable().remove(user);
+    }
+
 }

--- a/api/src/main/java/com/bivashy/auth/api/bucket/ModifiableBucket.java
+++ b/api/src/main/java/com/bivashy/auth/api/bucket/ModifiableBucket.java
@@ -1,0 +1,11 @@
+package com.bivashy.auth.api.bucket;
+
+import java.util.function.Predicate;
+
+public interface ModifiableBucket<T> extends Bucket<T> {
+    boolean add(T element);
+
+    boolean remove(T element);
+
+    void removeIf(Predicate<T> predicate);
+}

--- a/api/src/main/java/com/bivashy/auth/api/bucket/ModifiableBucket.java
+++ b/api/src/main/java/com/bivashy/auth/api/bucket/ModifiableBucket.java
@@ -3,9 +3,17 @@ package com.bivashy.auth.api.bucket;
 import java.util.function.Predicate;
 
 public interface ModifiableBucket<T> extends Bucket<T> {
+
     boolean add(T element);
+
+    default boolean addIfAbsent(T element) {
+        if (getUnmodifiableRaw().contains(element))
+            return false;
+        return add(element);
+    }
 
     boolean remove(T element);
 
     void removeIf(Predicate<T> predicate);
+
 }

--- a/core/src/main/java/me/mastercapexd/auth/BaseAuthPlugin.java
+++ b/core/src/main/java/me/mastercapexd/auth/BaseAuthPlugin.java
@@ -177,9 +177,9 @@ public class BaseAuthPlugin implements AuthPlugin {
     }
 
     private void registerTasks() {
-        this.taskBucket.addTask(new AuthenticationTimeoutTask(this));
-        this.taskBucket.addTask(new AuthenticationProgressBarTask(this));
-        this.taskBucket.addTask(new AuthenticationMessageSendTask(this));
+        this.taskBucket.modifiable().add(new AuthenticationTimeoutTask(this));
+        this.taskBucket.modifiable().add(new AuthenticationProgressBarTask(this));
+        this.taskBucket.modifiable().add(new AuthenticationMessageSendTask(this));
     }
 
     private void registerCryptoProviders() {

--- a/core/src/main/java/me/mastercapexd/auth/BaseAuthPlugin.java
+++ b/core/src/main/java/me/mastercapexd/auth/BaseAuthPlugin.java
@@ -166,15 +166,15 @@ public class BaseAuthPlugin implements AuthPlugin {
     }
 
     private void registerAuthenticationSteps() {
-        this.authenticationStepFactoryBucket.add(new NullAuthenticationStepFactory());
-        this.authenticationStepFactoryBucket.add(new LoginAuthenticationStepFactory());
-        this.authenticationStepFactoryBucket.add(new RegisterAuthenticationStepFactory());
-        this.authenticationStepFactoryBucket.add(new VKLinkAuthenticationStepFactory());
-        this.authenticationStepFactoryBucket.add(new GoogleLinkAuthenticationStepFactory());
-        this.authenticationStepFactoryBucket.add(new TelegramLinkAuthenticationStepFactory());
-        this.authenticationStepFactoryBucket.add(new DiscordLinkAuthenticationStepFactory());
-        this.authenticationStepFactoryBucket.add(new EnterServerAuthenticationStepFactory());
-        this.authenticationStepFactoryBucket.add(new EnterAuthServerAuthenticationStepFactory());
+        this.authenticationStepFactoryBucket.modifiable().add(new NullAuthenticationStepFactory());
+        this.authenticationStepFactoryBucket.modifiable().add(new LoginAuthenticationStepFactory());
+        this.authenticationStepFactoryBucket.modifiable().add(new RegisterAuthenticationStepFactory());
+        this.authenticationStepFactoryBucket.modifiable().add(new VKLinkAuthenticationStepFactory());
+        this.authenticationStepFactoryBucket.modifiable().add(new GoogleLinkAuthenticationStepFactory());
+        this.authenticationStepFactoryBucket.modifiable().add(new TelegramLinkAuthenticationStepFactory());
+        this.authenticationStepFactoryBucket.modifiable().add(new DiscordLinkAuthenticationStepFactory());
+        this.authenticationStepFactoryBucket.modifiable().add(new EnterServerAuthenticationStepFactory());
+        this.authenticationStepFactoryBucket.modifiable().add(new EnterAuthServerAuthenticationStepFactory());
     }
 
     private void registerTasks() {

--- a/core/src/main/java/me/mastercapexd/auth/BaseAuthPlugin.java
+++ b/core/src/main/java/me/mastercapexd/auth/BaseAuthPlugin.java
@@ -96,6 +96,7 @@ import net.kyori.adventure.platform.AudienceProvider;
 import ru.vyarus.yaml.updater.YamlUpdater;
 
 public class BaseAuthPlugin implements AuthPlugin {
+
     private final ConfigurationProcessor configurationProcessor = new SpongeConfigurateProcessor();
     private final Map<Class<? extends PluginHook>, PluginHook> hooks = new HashMap<>();
     private final AuthenticationTaskBucket taskBucket = new BaseAuthenticationTaskBucket();
@@ -146,7 +147,7 @@ public class BaseAuthPlugin implements AuthPlugin {
         if (config.isAutoMigrateConfigEnabled()) {
             try {
                 this.migrateConfig();
-            } catch(IOException | URISyntaxException e) {
+            } catch (IOException | URISyntaxException e) {
                 e.printStackTrace();
             }
         }
@@ -183,14 +184,14 @@ public class BaseAuthPlugin implements AuthPlugin {
     }
 
     private void registerCryptoProviders() {
-        this.cryptoProviderBucket.addCryptoProvider(new BcryptCryptoProvider());
-        this.cryptoProviderBucket.addCryptoProvider(new MessageDigestCryptoProvider("SHA256", HashUtils.getSHA256()));
-        this.cryptoProviderBucket.addCryptoProvider(new MessageDigestCryptoProvider("MD5", HashUtils.getMD5()));
-        this.cryptoProviderBucket.addCryptoProvider(new Argon2CryptoProvider());
-        this.cryptoProviderBucket.addCryptoProvider(new ScryptCryptoProvider());
+        this.cryptoProviderBucket.modifiable().add(new BcryptCryptoProvider());
+        this.cryptoProviderBucket.modifiable().add(new MessageDigestCryptoProvider("SHA256", HashUtils.getSHA256()));
+        this.cryptoProviderBucket.modifiable().add(new MessageDigestCryptoProvider("MD5", HashUtils.getMD5()));
+        this.cryptoProviderBucket.modifiable().add(new Argon2CryptoProvider());
+        this.cryptoProviderBucket.modifiable().add(new ScryptCryptoProvider());
 
-        this.cryptoProviderBucket.addCryptoProvider(new AuthMeSha256CryptoProvider());
-        this.cryptoProviderBucket.addCryptoProvider(new UAuthCryptoProvider());
+        this.cryptoProviderBucket.modifiable().add(new AuthMeSha256CryptoProvider());
+        this.cryptoProviderBucket.modifiable().add(new UAuthCryptoProvider());
     }
 
     private void initializeTelegram() {
@@ -231,7 +232,7 @@ public class BaseAuthPlugin implements AuthPlugin {
         configurationProcessor.registerFieldResolver(ConfigurationServer.class, (context) -> new BaseConfigurationServer(context.getString()))
                 .registerFieldResolver(ConfigurationDuration.class, (context) -> new ConfigurationDuration(TimeUtils.parseDuration(context.getString("1s"))))
                 .registerFieldResolverFactory(ConfigurationHolderMapResolverFactory.ConfigurationHolderMap.class, new ConfigurationHolderMapResolverFactory())
-                .registerFieldResolver(CryptoProvider.class, (context) -> cryptoProviderBucket.findCryptoProvider(context.getString())
+                .registerFieldResolver(CryptoProvider.class, (context) -> cryptoProviderBucket.findFirstByValue(CryptoProvider::getIdentifier, context.getString())
                         .orElseThrow(() -> new IllegalArgumentException("Cannot find CryptoProvider with name " + context.getString())))
                 .registerFieldResolver(ServerComponent.class, new ServerComponentFieldResolver())
                 .registerFieldResolverFactory(RawURLProvider.class, new RawURLProviderFieldResolverFactory())
@@ -372,4 +373,5 @@ public class BaseAuthPlugin implements AuthPlugin {
     public <T extends PluginHook> void putHook(Class<? extends T> clazz, T instance) {
         hooks.put(clazz, instance);
     }
+
 }

--- a/core/src/main/java/me/mastercapexd/auth/bucket/BaseAuthenticatingAccountBucket.java
+++ b/core/src/main/java/me/mastercapexd/auth/bucket/BaseAuthenticatingAccountBucket.java
@@ -1,18 +1,14 @@
 package me.mastercapexd.auth.bucket;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-
 import com.bivashy.auth.api.AuthPlugin;
 import com.bivashy.auth.api.account.Account;
 import com.bivashy.auth.api.bucket.AuthenticatingAccountBucket;
+import com.bivashy.auth.api.bucket.AuthenticatingAccountBucket.AuthenticatingAccountState;
 import com.bivashy.auth.api.event.AccountStateClearEvent;
 import com.bivashy.auth.api.model.PlayerIdSupplier;
 
-public class BaseAuthenticatingAccountBucket implements AuthenticatingAccountBucket {
-    private final Map<String, AuthenticatingAccountState> authenticatingAccounts = new HashMap<>();
+public class BaseAuthenticatingAccountBucket extends BaseListBucket<AuthenticatingAccountState> implements AuthenticatingAccountBucket {
+
     private final AuthPlugin plugin;
 
     public BaseAuthenticatingAccountBucket(AuthPlugin plugin) {
@@ -20,52 +16,38 @@ public class BaseAuthenticatingAccountBucket implements AuthenticatingAccountBuc
     }
 
     @Override
-    public Collection<String> getAccountIdEntries() {
-        return authenticatingAccounts.keySet();
-    }
-
-    @Override
-    public boolean isAuthenticating(PlayerIdSupplier playerIdSupplier) {
-        return authenticatingAccounts.containsKey(playerIdSupplier.getPlayerId());
-    }
-
-    @Override
-    public Optional<Account> getAuthenticatingAccount(PlayerIdSupplier playerIdSupplier) {
-        return Optional.ofNullable(authenticatingAccounts.getOrDefault(playerIdSupplier.getPlayerId(), null)).map(AuthenticatingAccountState::getAccount);
-    }
-
-    @Override
-    public Optional<Long> getEnterTimestamp(PlayerIdSupplier playerIdSupplier) {
-        return Optional.ofNullable(authenticatingAccounts.getOrDefault(playerIdSupplier.getPlayerId(), null))
-                .map(AuthenticatingAccountState::getEnterTimestamp);
-    }
-
-    @Override
     public void addAuthenticatingAccount(Account account) {
-        authenticatingAccounts.put(account.getPlayerId(), new AuthenticatingAccountState(account, System.currentTimeMillis()));
+        if (hasByValue(AuthenticatingAccountState::getPlayerId, account.getPlayerId()))
+            return;
+        modifiable().add(new BaseAuthenticatingAccountState(account, System.currentTimeMillis()));
     }
 
     @Override
     public void removeAuthenticatingAccount(PlayerIdSupplier playerIdSupplier) {
         plugin.getEventBus().post(AccountStateClearEvent.class, getAuthenticatingAccount(playerIdSupplier));
-        authenticatingAccounts.remove(playerIdSupplier.getPlayerId());
+        modifiable().removeIf(accountState -> accountState.getPlayerId().equals(playerIdSupplier.getPlayerId()));
     }
 
-    public static class AuthenticatingAccountState {
+    public static class BaseAuthenticatingAccountState implements AuthenticatingAccountState {
+
         private final Account account;
         private final long enterTimestamp;
 
-        public AuthenticatingAccountState(Account account, long enterTimestamp) {
+        public BaseAuthenticatingAccountState(Account account, long enterTimestamp) {
             this.account = account;
             this.enterTimestamp = enterTimestamp;
         }
 
+        @Override
         public Account getAccount() {
             return account;
         }
 
+        @Override
         public long getEnterTimestamp() {
             return enterTimestamp;
         }
+
     }
+
 }

--- a/core/src/main/java/me/mastercapexd/auth/bucket/BaseAuthenticationStepContextFactoryBucket.java
+++ b/core/src/main/java/me/mastercapexd/auth/bucket/BaseAuthenticationStepContextFactoryBucket.java
@@ -1,62 +1,35 @@
 package me.mastercapexd.auth.bucket;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Optional;
 
 import com.bivashy.auth.api.account.Account;
 import com.bivashy.auth.api.bucket.AuthenticationStepContextFactoryBucket;
+import com.bivashy.auth.api.bucket.AuthenticationStepContextFactoryBucket.AuthenticationStepContextFactoryWrapper;
 import com.bivashy.auth.api.factory.AuthenticationStepContextFactory;
 import com.bivashy.auth.api.step.AuthenticationStepContext;
 
 import me.mastercapexd.auth.step.context.BaseAuthenticationStepContext;
 
-public class BaseAuthenticationStepContextFactoryBucket implements AuthenticationStepContextFactoryBucket {
-    private final Map<String, AuthenticationStepContextFactory> authenticationStepContextFactories = new HashMap<>();
+public class BaseAuthenticationStepContextFactoryBucket extends BaseListBucket<AuthenticationStepContextFactoryWrapper> implements AuthenticationStepContextFactoryBucket {
+
     private final List<String> stepNames;
 
     public BaseAuthenticationStepContextFactoryBucket(List<String> stepNames) {
         this.stepNames = stepNames;
     }
 
-    public Map<String, AuthenticationStepContextFactory> getMap() {
-        return Collections.unmodifiableMap(authenticationStepContextFactories);
-    }
-
-    public AuthenticationStepContextFactory put(String key, AuthenticationStepContextFactory value) {
-        return authenticationStepContextFactories.put(key, value);
-    }
-
-    public AuthenticationStepContextFactory remove(String key) {
-        return authenticationStepContextFactories.remove(key);
-    }
-
-    public AuthenticationStepContextFactory get(String key) {
-        return authenticationStepContextFactories.get(key);
-    }
-
-    public AuthenticationStepContextFactory getOrDefault(String key, AuthenticationStepContextFactory def) {
-        return authenticationStepContextFactories.getOrDefault(key, def);
-    }
-
-    public boolean containsKey(String key) {
-        return authenticationStepContextFactories.containsKey(key);
-    }
-
     public AuthenticationStepContext createContext(Account account) {
-        String stepName = stepNames.get(0); // Use first stepName by default
-        if (stepNames.size() > account.getCurrentAuthenticationStepCreatorIndex()) // If current
-            // authentication step
-            // index not out of
-            // bounds stepNames size
-            stepName = stepNames.get(account.getCurrentAuthenticationStepCreatorIndex()); // use this step
-        // name
+        String stepName = stepNames.get(0);
+        if (stepNames.size() > account.getCurrentAuthenticationStepCreatorIndex())
+            stepName = stepNames.get(account.getCurrentAuthenticationStepCreatorIndex());
         return createContext(stepName, account);
     }
 
     public AuthenticationStepContext createContext(String stepName, Account account) {
-        return authenticationStepContextFactories.getOrDefault(stepName, AuthenticationStepContextFactory.of(new BaseAuthenticationStepContext(account)))
-                .createContext(account);
+        Optional<AuthenticationStepContextFactoryWrapper> wrapperOptional = findFirstByValue(AuthenticationStepContextFactoryWrapper::getIdentifier, stepName);
+        AuthenticationStepContextFactory defaultFactory = AuthenticationStepContextFactory.of(new BaseAuthenticationStepContext(account));
+        return wrapperOptional.orElse(AuthenticationStepContextFactoryWrapper.of(stepName, defaultFactory)).createContext(account);
     }
+
 }

--- a/core/src/main/java/me/mastercapexd/auth/bucket/BaseAuthenticationStepFactoryBucket.java
+++ b/core/src/main/java/me/mastercapexd/auth/bucket/BaseAuthenticationStepFactoryBucket.java
@@ -1,44 +1,8 @@
 package me.mastercapexd.auth.bucket;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Predicate;
-
 import com.bivashy.auth.api.bucket.AuthenticationStepFactoryBucket;
 import com.bivashy.auth.api.factory.AuthenticationStepFactory;
 
-public class BaseAuthenticationStepFactoryBucket implements AuthenticationStepFactoryBucket {
-    private final List<AuthenticationStepFactory> authenticationSteps = new ArrayList<>();
+public class BaseAuthenticationStepFactoryBucket extends BaseListBucket<AuthenticationStepFactory> implements AuthenticationStepFactoryBucket {
 
-    public List<AuthenticationStepFactory> getList() {
-        return Collections.unmodifiableList(authenticationSteps);
-    }
-
-    public void add(AuthenticationStepFactory authenticationStepCreator) {
-        if (authenticationStepCreator == null)
-            return;
-        if (authenticationSteps.contains(authenticationStepCreator))
-            return;
-        if (authenticationSteps.stream()
-                .anyMatch(authStep -> authStep.getAuthenticationStepName().equals(authenticationStepCreator.getAuthenticationStepName())))
-            return;
-        authenticationSteps.add(authenticationStepCreator);
-    }
-
-    public void remove(AuthenticationStepFactory authenticationStepCreator) {
-        if (authenticationStepCreator == null)
-            return;
-        authenticationSteps.remove(authenticationStepCreator);
-    }
-
-    public Iterator<AuthenticationStepFactory> iterator() {
-        return authenticationSteps.iterator();
-    }
-
-    public Optional<AuthenticationStepFactory> findFirst(Predicate<AuthenticationStepFactory> filter) {
-        return authenticationSteps.stream().filter(filter).findFirst();
-    }
 }

--- a/core/src/main/java/me/mastercapexd/auth/bucket/BaseAuthenticationTaskBucket.java
+++ b/core/src/main/java/me/mastercapexd/auth/bucket/BaseAuthenticationTaskBucket.java
@@ -1,15 +1,8 @@
 package me.mastercapexd.auth.bucket;
 
-import java.util.List;
-
 import com.bivashy.auth.api.bucket.AuthenticationTaskBucket;
 import com.bivashy.auth.api.model.AuthenticationTask;
 
 public class BaseAuthenticationTaskBucket extends BaseListBucket<AuthenticationTask> implements AuthenticationTaskBucket {
-
-    @Override
-    public List<AuthenticationTask> getTasks() {
-        return (List<AuthenticationTask>) getUnmodifiableRaw();
-    }
 
 }

--- a/core/src/main/java/me/mastercapexd/auth/bucket/BaseAuthenticationTaskBucket.java
+++ b/core/src/main/java/me/mastercapexd/auth/bucket/BaseAuthenticationTaskBucket.java
@@ -1,27 +1,18 @@
 package me.mastercapexd.auth.bucket;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import com.bivashy.auth.api.bucket.AuthenticationTaskBucket;
 import com.bivashy.auth.api.model.AuthenticationTask;
 
-public class BaseAuthenticationTaskBucket implements AuthenticationTaskBucket {
-    private final List<AuthenticationTask> tasks = new ArrayList<>();
-
-    @Override
-    public void addTask(AuthenticationTask task) {
-        tasks.add(task);
-    }
-
-    @Override
-    public void removeTask(AuthenticationTask task) {
-        tasks.remove(task);
+public class BaseAuthenticationTaskBucket extends BaseListBucket<AuthenticationTask> implements AuthenticationTaskBucket {
+    public BaseAuthenticationTaskBucket() {
+        super(new ArrayList<>());
     }
 
     @Override
     public List<AuthenticationTask> getTasks() {
-        return Collections.unmodifiableList(tasks);
+        return (List<AuthenticationTask>) getUnmodifiableRaw();
     }
 }

--- a/core/src/main/java/me/mastercapexd/auth/bucket/BaseAuthenticationTaskBucket.java
+++ b/core/src/main/java/me/mastercapexd/auth/bucket/BaseAuthenticationTaskBucket.java
@@ -1,18 +1,15 @@
 package me.mastercapexd.auth.bucket;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import com.bivashy.auth.api.bucket.AuthenticationTaskBucket;
 import com.bivashy.auth.api.model.AuthenticationTask;
 
 public class BaseAuthenticationTaskBucket extends BaseListBucket<AuthenticationTask> implements AuthenticationTaskBucket {
-    public BaseAuthenticationTaskBucket() {
-        super(new ArrayList<>());
-    }
 
     @Override
     public List<AuthenticationTask> getTasks() {
         return (List<AuthenticationTask>) getUnmodifiableRaw();
     }
+
 }

--- a/core/src/main/java/me/mastercapexd/auth/bucket/BaseCryptoProviderBucket.java
+++ b/core/src/main/java/me/mastercapexd/auth/bucket/BaseCryptoProviderBucket.java
@@ -1,22 +1,14 @@
 package me.mastercapexd.auth.bucket;
 
 import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 
 import com.bivashy.auth.api.bucket.CryptoProviderBucket;
 import com.bivashy.auth.api.crypto.CryptoProvider;
 
-public class BaseCryptoProviderBucket implements CryptoProviderBucket {
-    private final List<CryptoProvider> cryptoProviders = new ArrayList<>();
+public class BaseCryptoProviderBucket extends BaseListBucket<CryptoProvider> implements CryptoProviderBucket {
 
-    @Override
-    public Optional<CryptoProvider> findCryptoProvider(String identifier) {
-        return cryptoProviders.stream().filter(provider -> provider.getIdentifier().equals(identifier)).findFirst();
+    public BaseCryptoProviderBucket() {
+        super(new ArrayList<>());
     }
 
-    @Override
-    public void addCryptoProvider(CryptoProvider cryptoProvider) {
-        cryptoProviders.add(cryptoProvider);
-    }
 }

--- a/core/src/main/java/me/mastercapexd/auth/bucket/BaseCryptoProviderBucket.java
+++ b/core/src/main/java/me/mastercapexd/auth/bucket/BaseCryptoProviderBucket.java
@@ -1,14 +1,8 @@
 package me.mastercapexd.auth.bucket;
 
-import java.util.ArrayList;
-
 import com.bivashy.auth.api.bucket.CryptoProviderBucket;
 import com.bivashy.auth.api.crypto.CryptoProvider;
 
 public class BaseCryptoProviderBucket extends BaseListBucket<CryptoProvider> implements CryptoProviderBucket {
-
-    public BaseCryptoProviderBucket() {
-        super(new ArrayList<>());
-    }
 
 }

--- a/core/src/main/java/me/mastercapexd/auth/bucket/BaseLinkAuthenticationBucket.java
+++ b/core/src/main/java/me/mastercapexd/auth/bucket/BaseLinkAuthenticationBucket.java
@@ -1,51 +1,8 @@
 package me.mastercapexd.auth.bucket;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
 import com.bivashy.auth.api.bucket.LinkAuthenticationBucket;
-import com.bivashy.auth.api.link.LinkType;
 import com.bivashy.auth.api.link.user.LinkUser;
 
-public class BaseLinkAuthenticationBucket<T extends LinkUser> implements LinkAuthenticationBucket<T> {
-    private final List<T> linkUsers = new ArrayList<>();
+public class BaseLinkAuthenticationBucket<T extends LinkUser> extends BaseListBucket<T> implements LinkAuthenticationBucket<T> {
 
-    public boolean hasLinkUser(Predicate<T> filter) {
-        return linkUsers.stream().anyMatch(filter);
-    }
-
-    public boolean hasLinkUser(String id, LinkType linkType) {
-        return hasLinkUser(linkUser -> linkUser.getAccount().getPlayerId().equals(id) && linkUser.getLinkType().equals(linkType));
-    }
-
-    public void addLinkUser(T linkUser) {
-        linkUsers.add(linkUser);
-    }
-
-    public void removeLinkUsers(Predicate<T> filter) {
-        linkUsers.removeIf(filter);
-    }
-
-    public void removeLinkUser(String id, LinkType linkType) {
-        removeLinkUsers(linkUser -> linkUser.getAccount().getPlayerId().equals(id) && linkUser.getLinkType().equals(linkType));
-    }
-
-    public void removeLinkUser(T linkUser) {
-        linkUsers.remove(linkUser);
-    }
-
-    public Optional<T> findFirstLinkUser(Predicate<T> filter) {
-        return linkUsers.stream().filter(filter).findFirst();
-    }
-
-    public List<T> getLinkUsers(Predicate<T> filter) {
-        return linkUsers.stream().filter(filter).collect(Collectors.toList());
-    }
-
-    public T getLinkUser(String id, LinkType linkType) {
-        return findFirstLinkUser(linkUser -> linkUser.getAccount().getPlayerId().equals(id) && linkUser.getLinkType().equals(linkType)).orElse(null);
-    }
 }

--- a/core/src/main/java/me/mastercapexd/auth/bucket/BaseLinkConfirmationBucket.java
+++ b/core/src/main/java/me/mastercapexd/auth/bucket/BaseLinkConfirmationBucket.java
@@ -1,28 +1,8 @@
 package me.mastercapexd.auth.bucket;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-
 import com.bivashy.auth.api.bucket.LinkConfirmationBucket;
 import com.bivashy.auth.api.link.user.confirmation.LinkConfirmationUser;
 
-public class BaseLinkConfirmationBucket implements LinkConfirmationBucket {
-    private final List<LinkConfirmationUser> confirmationUsers = new ArrayList<>();
+public class BaseLinkConfirmationBucket extends BaseListBucket<LinkConfirmationUser> implements LinkConfirmationBucket {
 
-    @Override
-    public Collection<LinkConfirmationUser> getConfirmationUsers() {
-        return Collections.unmodifiableCollection(confirmationUsers);
-    }
-
-    @Override
-    public void addLinkConfirmation(LinkConfirmationUser user) {
-        confirmationUsers.add(user);
-    }
-
-    @Override
-    public void removeLinkConfirmation(LinkConfirmationUser user) {
-        confirmationUsers.remove(user);
-    }
 }

--- a/core/src/main/java/me/mastercapexd/auth/bucket/BaseListBucket.java
+++ b/core/src/main/java/me/mastercapexd/auth/bucket/BaseListBucket.java
@@ -1,0 +1,38 @@
+package me.mastercapexd.auth.bucket;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import com.bivashy.auth.api.bucket.Bucket;
+import com.bivashy.auth.api.bucket.ModifiableBucket;
+
+public class BaseListBucket<T> implements Bucket<T> {
+    private final List<T> list;
+    private final ModifiableBucket<T> modifiableBucket;
+
+    public BaseListBucket(List<T> list, ModifiableBucket<T> modifiableBucket) {
+        this.list = list;
+        this.modifiableBucket = modifiableBucket;
+    }
+
+    public BaseListBucket(List<T> list) {
+        this(list, new BaseModifiableListBucket<>(list));
+    }
+
+    @Override
+    public Collection<T> getUnmodifiableRaw() {
+        return Collections.unmodifiableList(list);
+    }
+
+    @Override
+    public Stream<T> stream() {
+        return list.stream();
+    }
+
+    @Override
+    public ModifiableBucket<T> modifiable() {
+        return modifiableBucket;
+    }
+}

--- a/core/src/main/java/me/mastercapexd/auth/bucket/BaseListBucket.java
+++ b/core/src/main/java/me/mastercapexd/auth/bucket/BaseListBucket.java
@@ -1,5 +1,6 @@
 package me.mastercapexd.auth.bucket;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -19,6 +20,10 @@ public class BaseListBucket<T> implements Bucket<T> {
 
     public BaseListBucket(List<T> list) {
         this(list, new BaseModifiableListBucket<>(list));
+    }
+
+    public BaseListBucket(){
+        this(new ArrayList<>());
     }
 
     @Override

--- a/core/src/main/java/me/mastercapexd/auth/bucket/BaseModifiableListBucket.java
+++ b/core/src/main/java/me/mastercapexd/auth/bucket/BaseModifiableListBucket.java
@@ -1,0 +1,47 @@
+package me.mastercapexd.auth.bucket;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import com.bivashy.auth.api.bucket.ModifiableBucket;
+
+public class BaseModifiableListBucket<T> implements ModifiableBucket<T> {
+    private final List<T> list;
+
+    public BaseModifiableListBucket(List<T> list) {
+        this.list = list;
+    }
+
+    @Override
+    public Collection<T> getUnmodifiableRaw() {
+        return Collections.unmodifiableList(list);
+    }
+
+    @Override
+    public Stream<T> stream() {
+        return list.stream();
+    }
+
+    @Override
+    public ModifiableBucket<T> modifiable() {
+        return this;
+    }
+
+    @Override
+    public boolean add(T element) {
+        return list.add(element);
+    }
+
+    @Override
+    public boolean remove(T element) {
+        return list.remove(element);
+    }
+
+    @Override
+    public void removeIf(Predicate<T> predicate) {
+        list.removeIf(predicate);
+    }
+}

--- a/core/src/main/java/me/mastercapexd/auth/database/persister/CryptoProviderPersister.java
+++ b/core/src/main/java/me/mastercapexd/auth/database/persister/CryptoProviderPersister.java
@@ -25,7 +25,7 @@ public class CryptoProviderPersister extends BaseDataType {
     }
 
     @Override
-    public Object javaToSqlArg(FieldType fieldType, Object javaObject) throws SQLException {
+    public Object javaToSqlArg(FieldType fieldType, Object javaObject) {
         CryptoProvider cryptoProvider = (CryptoProvider) javaObject;
         return cryptoProvider.getIdentifier();
     }
@@ -38,7 +38,7 @@ public class CryptoProviderPersister extends BaseDataType {
             String identifier = (String) sqlArg;
             return AuthPlugin.instance()
                     .getCryptoProviderBucket()
-                    .findCryptoProvider(identifier)
+                    .findFirstByValue(CryptoProvider::getIdentifier, identifier)
                     .orElseThrow(() -> new SQLException("Cannot get crypto provider value of '" + identifier + "' for field " + fieldType));
         }
     }

--- a/core/src/main/java/me/mastercapexd/auth/messenger/commands/AccountEnterAcceptCommand.java
+++ b/core/src/main/java/me/mastercapexd/auth/messenger/commands/AccountEnterAcceptCommand.java
@@ -28,7 +28,7 @@ public class AccountEnterAcceptCommand implements OrphanCommand {
 
     @DefaultFor("~")
     public void onAccept(LinkCommandActorWrapper actorWrapper, LinkType linkType, @Default("all") String acceptPlayerName) {
-        List<LinkEntryUser> accounts = plugin.getLinkEntryBucket().getLinkUsers(entryUser -> {
+        List<LinkEntryUser> accounts = plugin.getLinkEntryBucket().find(entryUser -> {
             if (!entryUser.getLinkType().equals(linkType))
                 return false;
 
@@ -57,7 +57,7 @@ public class AccountEnterAcceptCommand implements OrphanCommand {
             account.getPlayer().ifPresent(player -> player.sendMessage(linkType.getServerMessages().getStringMessage("enter-confirmed",
                     linkType.newMessageContext(account))));
             account.nextAuthenticationStep(plugin.getAuthenticationContextFactoryBucket().createContext(account));
-            plugin.getLinkEntryBucket().removeLinkUser(entryUser);
+            plugin.getLinkEntryBucket().modifiable().remove(entryUser);
 
             actorWrapper.reply(linkType.getLinkMessages().getMessage("enter-accepted", linkType.newMessageContext(account)));
         }));

--- a/core/src/main/java/me/mastercapexd/auth/messenger/commands/AccountEnterDeclineCommand.java
+++ b/core/src/main/java/me/mastercapexd/auth/messenger/commands/AccountEnterDeclineCommand.java
@@ -27,7 +27,7 @@ public class AccountEnterDeclineCommand implements OrphanCommand {
 
     @DefaultFor("~")
     public void onDecline(LinkCommandActorWrapper actorWrapper, LinkType linkType, @Default("all") String declinePlayerName) {
-        List<LinkEntryUser> accounts = plugin.getLinkEntryBucket().getLinkUsers(entryUser -> {
+        List<LinkEntryUser> accounts = plugin.getLinkEntryBucket().find(entryUser -> {
             if (!entryUser.getLinkType().equals(linkType))
                 return false;
 
@@ -51,7 +51,7 @@ public class AccountEnterDeclineCommand implements OrphanCommand {
                 actorWrapper).thenAccept(result -> {
             if (result.getEvent().isCancelled())
                 return;
-            plugin.getLinkEntryBucket().removeLinkUser(entryUser);
+            plugin.getLinkEntryBucket().modifiable().remove(entryUser);
             entryUser.getAccount()
                     .kick(linkType.getServerMessages().getStringMessage("enter-declined", linkType.newMessageContext(entryUser.getAccount())));
             actorWrapper.reply(linkType.getLinkMessages().getMessage("enter-declined", linkType.newMessageContext(entryUser.getAccount())));

--- a/core/src/main/java/me/mastercapexd/auth/messenger/commands/GoogleCodeCommand.java
+++ b/core/src/main/java/me/mastercapexd/auth/messenger/commands/GoogleCodeCommand.java
@@ -38,7 +38,7 @@ public class GoogleCodeCommand implements OrphanCommand {
             return;
         }
 
-        if (!plugin.getLinkEntryBucket().hasLinkUser(account.getPlayerId(), GoogleLinkType.getInstance())) {
+        if (!plugin.getLinkEntryBucket().find(account.getPlayerId(), GoogleLinkType.getInstance()).isPresent()) {
             actorWrapper.reply(linkType.getLinkMessages().getStringMessage("google-code-not-need-enter", linkType.newMessageContext(account)));
             return;
         }

--- a/core/src/main/java/me/mastercapexd/auth/server/commands/GoogleCodeCommand.java
+++ b/core/src/main/java/me/mastercapexd/auth/server/commands/GoogleCodeCommand.java
@@ -42,7 +42,7 @@ public class GoogleCodeCommand {
             player.sendMessage(GOOGLE_MESSAGES.getMessage("code-not-exists"));
             return;
         }
-        if (!plugin.getLinkEntryBucket().hasLinkUser(playerId, GoogleLinkType.getInstance())) {
+        if (!plugin.getLinkEntryBucket().find(playerId, GoogleLinkType.getInstance()).isPresent()) {
             player.sendMessage(GOOGLE_MESSAGES.getMessage("code-not-need-enter"));
             return;
         }

--- a/core/src/main/java/me/mastercapexd/auth/shared/commands/LinkCodeCommand.java
+++ b/core/src/main/java/me/mastercapexd/auth/shared/commands/LinkCodeCommand.java
@@ -60,7 +60,7 @@ public class LinkCodeCommand implements OrphanCommand {
                         accountDatabase.updateAccountLinks(account);
 
                         actor.replyWithMessage(messages.getMessage("confirmation-success"));
-                        linkConfirmationBucket.removeLinkConfirmation(linkContext.getConfirmationUser());
+                        linkConfirmationBucket.modifiable().remove(linkContext.getConfirmationUser());
                     });
                 }));
     }

--- a/core/src/main/java/me/mastercapexd/auth/shared/commands/MessengerLinkCommandTemplate.java
+++ b/core/src/main/java/me/mastercapexd/auth/shared/commands/MessengerLinkCommandTemplate.java
@@ -44,7 +44,7 @@ public class MessengerLinkCommandTemplate implements OrphanCommand {
     }
 
     public void sendLinkConfirmation(MessageableCommandActor commandActor, LinkConfirmationUser confirmationUser) {
-        plugin.getLinkConfirmationBucket().addLinkConfirmation(confirmationUser);
+        plugin.getLinkConfirmationBucket().modifiable().add(confirmationUser);
         commandActor.replyWithMessage(messages.getMessage("confirmation-sent", MessageContext.of("%code%", confirmationUser.getConfirmationCode())));
     }
 

--- a/core/src/main/java/me/mastercapexd/auth/step/impl/link/GoogleCodeAuthenticationStep.java
+++ b/core/src/main/java/me/mastercapexd/auth/step/impl/link/GoogleCodeAuthenticationStep.java
@@ -42,7 +42,7 @@ public class GoogleCodeAuthenticationStep extends AuthenticationStepTemplate imp
         if (!PLUGIN.getConfig().getGoogleAuthenticatorSettings().isEnabled())
             return true;
 
-        if (PLUGIN.getLinkEntryBucket().hasLinkUser(account.getPlayerId(), GoogleLinkType.getInstance()))
+        if (PLUGIN.getLinkEntryBucket().find(account.getPlayerId(), GoogleLinkType.getInstance()).isPresent())
             return true;
 
         if (account.isSessionActive(PLUGIN.getConfig().getSessionDurability()))
@@ -57,7 +57,7 @@ public class GoogleCodeAuthenticationStep extends AuthenticationStepTemplate imp
             if (!linkUserInfo.isConfirmationEnabled() && GoogleLinkType.getInstance().getSettings().getConfirmationSettings().canToggleConfirmation())
                 return true;
 
-            PLUGIN.getLinkEntryBucket().addLinkUser(entryUser);
+            PLUGIN.getLinkEntryBucket().modifiable().add(entryUser);
             return false;
         }).orElse(true);
     }

--- a/core/src/main/java/me/mastercapexd/auth/step/impl/link/MessengerAuthenticationStep.java
+++ b/core/src/main/java/me/mastercapexd/auth/step/impl/link/MessengerAuthenticationStep.java
@@ -43,7 +43,7 @@ public class MessengerAuthenticationStep extends AuthenticationStepTemplate impl
         if (!linkType.getSettings().isEnabled())
             return true;
 
-        if (PLUGIN.getLinkEntryBucket().hasLinkUser(account.getPlayerId(), linkType))
+        if (PLUGIN.getLinkEntryBucket().find(account.getPlayerId(), linkType).isPresent())
             return true;
 
         if (account.isSessionActive(PLUGIN.getConfig().getSessionDurability()))
@@ -66,7 +66,7 @@ public class MessengerAuthenticationStep extends AuthenticationStepTemplate impl
         if (linkType.getSettings().getConfirmationSettings().canToggleConfirmation() && !linkUserInfo.isConfirmationEnabled())
             return true;
 
-        PLUGIN.getLinkEntryBucket().addLinkUser(linkEntryUser);
+        PLUGIN.getLinkEntryBucket().modifiable().add(linkEntryUser);
 
         sendConfirmationMessage(account, linkType, linkUserInfo);
         return false;

--- a/core/src/main/java/me/mastercapexd/auth/task/AuthenticationTimeoutTask.java
+++ b/core/src/main/java/me/mastercapexd/auth/task/AuthenticationTimeoutTask.java
@@ -28,7 +28,7 @@ public class AuthenticationTimeoutTask implements AuthenticationTask {
                 int accountEnterElapsedMillis = (int) (now -
                         plugin.getAuthenticatingAccountBucket().getEnterTimestampOrZero(PlayerIdSupplier.of(accountPlayerId)));
 
-                for (LinkEntryUser entryUser : plugin.getLinkEntryBucket().getLinkUsers(user -> user.getAccount().getPlayerId().equals(account.getPlayerId())))
+                for (LinkEntryUser entryUser : plugin.getLinkEntryBucket().find(user -> user.getAccount().getPlayerId().equals(account.getPlayerId())))
                     if (entryUser != null)
                         try {
                             authTimeoutMillis += entryUser.getLinkType().getSettings().getEnterSettings().getEnterDelay();


### PR DESCRIPTION
Added `Bucket`, `ModifiableBucket` classes, and implemented in all existing bucket classes.

Old bucket methods, except `AuthenticatingAccountBucket` was deprecated, and were replaced by `Bucket`, `ModifiableBucket` methods.