### PR TITLE
Replace AuthAccountProvider by AuthAccountAdapter

### DIFF
--- a/api/src/main/java/com/bivashy/auth/api/account/Account.java
+++ b/api/src/main/java/com/bivashy/auth/api/account/Account.java
@@ -20,6 +20,9 @@ import com.bivashy.auth.api.type.IdentifierType;
 import com.bivashy.auth.api.type.KickResultType;
 
 public interface Account extends PlayerIdSupplier {
+
+    long getDatabaseId();
+
     @Deprecated
     default String getId() {
         return getPlayerId();
@@ -149,4 +152,5 @@ public interface Account extends PlayerIdSupplier {
     default boolean isRegistered() {
         return getPasswordHash().getHash() != null;
     }
+
 }

--- a/core/src/main/java/me/mastercapexd/auth/account/AuthAccountAdapter.java
+++ b/core/src/main/java/me/mastercapexd/auth/account/AuthAccountAdapter.java
@@ -15,10 +15,10 @@ import com.bivashy.auth.api.type.IdentifierType;
 
 import me.mastercapexd.auth.database.model.AccountLink;
 import me.mastercapexd.auth.database.model.AuthAccount;
-import me.mastercapexd.auth.database.model.AuthAccountProvider;
 import me.mastercapexd.auth.link.user.AccountLinkAdapter;
 
-public class AuthAccountAdapter extends AccountTemplate implements AuthAccountProvider {
+public class AuthAccountAdapter extends AccountTemplate {
+
     private final List<LinkUser> linkUsers;
     private final AuthAccount authAccount;
 
@@ -47,8 +47,8 @@ public class AuthAccountAdapter extends AccountTemplate implements AuthAccountPr
     }
 
     @Override
-    public AuthAccount getAuthAccount() {
-        return authAccount;
+    public long getDatabaseId() {
+        return authAccount.getId();
     }
 
     @Override
@@ -144,4 +144,5 @@ public class AuthAccountAdapter extends AccountTemplate implements AuthAccountPr
     public int compareTo(AccountTemplate accountTemplate) {
         return accountTemplate.getName().compareTo(getName());
     }
+
 }

--- a/core/src/main/java/me/mastercapexd/auth/database/adapter/AccountAdapter.java
+++ b/core/src/main/java/me/mastercapexd/auth/database/adapter/AccountAdapter.java
@@ -1,0 +1,15 @@
+package me.mastercapexd.auth.database.adapter;
+
+import com.bivashy.auth.api.account.Account;
+
+import me.mastercapexd.auth.database.model.AuthAccount;
+
+public class AccountAdapter extends AuthAccount {
+
+    public AccountAdapter(Account account) {
+        super(account.getDatabaseId(), account.getPlayerId(), account.getIdentifierType(), account.getCryptoProvider(), account.getLastIpAddress(),
+                account.getUniqueId(), account.getName(), account.getPasswordHash()
+                        .getHash(), account.getLastQuitTimestamp(), account.getLastSessionStartTimestamp());
+    }
+
+}

--- a/core/src/main/java/me/mastercapexd/auth/database/adapter/AccountLinkAdapter.java
+++ b/core/src/main/java/me/mastercapexd/auth/database/adapter/AccountLinkAdapter.java
@@ -1,0 +1,14 @@
+package me.mastercapexd.auth.database.adapter;
+
+import com.bivashy.auth.api.link.user.LinkUser;
+
+import me.mastercapexd.auth.database.model.AccountLink;
+
+public class AccountLinkAdapter extends AccountLink {
+
+    public AccountLinkAdapter(LinkUser linkUser) {
+        super(linkUser.getLinkType().getName(), linkUser.getLinkUserInfo().getIdentificator().asString(), linkUser.getLinkUserInfo().isConfirmationEnabled(),
+                null);
+    }
+
+}

--- a/core/src/main/java/me/mastercapexd/auth/database/adapter/AccountLinkAdapter.java
+++ b/core/src/main/java/me/mastercapexd/auth/database/adapter/AccountLinkAdapter.java
@@ -3,12 +3,13 @@ package me.mastercapexd.auth.database.adapter;
 import com.bivashy.auth.api.link.user.LinkUser;
 
 import me.mastercapexd.auth.database.model.AccountLink;
+import me.mastercapexd.auth.database.model.AuthAccount;
 
 public class AccountLinkAdapter extends AccountLink {
 
-    public AccountLinkAdapter(LinkUser linkUser) {
+    public AccountLinkAdapter(LinkUser linkUser, AuthAccount account) {
         super(linkUser.getLinkType().getName(), linkUser.getLinkUserInfo().getIdentificator().asString(), linkUser.getLinkUserInfo().isConfirmationEnabled(),
-                null);
+                account);
     }
 
 }

--- a/core/src/main/java/me/mastercapexd/auth/database/adapter/LinkUserAdapter.java
+++ b/core/src/main/java/me/mastercapexd/auth/database/adapter/LinkUserAdapter.java
@@ -5,9 +5,9 @@ import com.bivashy.auth.api.link.user.LinkUser;
 import me.mastercapexd.auth.database.model.AccountLink;
 import me.mastercapexd.auth.database.model.AuthAccount;
 
-public class AccountLinkAdapter extends AccountLink {
+public class LinkUserAdapter extends AccountLink {
 
-    public AccountLinkAdapter(LinkUser linkUser, AuthAccount account) {
+    public LinkUserAdapter(LinkUser linkUser, AuthAccount account) {
         super(linkUser.getLinkType().getName(), linkUser.getLinkUserInfo().getIdentificator().asString(), linkUser.getLinkUserInfo().isConfirmationEnabled(),
                 account);
     }

--- a/core/src/main/java/me/mastercapexd/auth/database/dao/AuthAccountDao.java
+++ b/core/src/main/java/me/mastercapexd/auth/database/dao/AuthAccountDao.java
@@ -21,9 +21,9 @@ import com.j256.ormlite.table.DatabaseTableConfig;
 import com.j256.ormlite.table.TableUtils;
 
 import me.mastercapexd.auth.database.DatabaseHelper;
+import me.mastercapexd.auth.database.adapter.AccountAdapter;
 import me.mastercapexd.auth.database.model.AccountLink;
 import me.mastercapexd.auth.database.model.AuthAccount;
-import me.mastercapexd.auth.database.model.AuthAccountProvider;
 import me.mastercapexd.auth.database.persister.CryptoProviderPersister;
 
 public class AuthAccountDao extends BaseDaoImpl<AuthAccount, Long> {
@@ -153,10 +153,7 @@ public class AuthAccountDao extends BaseDaoImpl<AuthAccount, Long> {
     }
 
     public AuthAccount createOrUpdateAccount(Account account) {
-        if (!(account instanceof AuthAccountProvider))
-            throw new IllegalArgumentException("Cannot create or update not AuthAccountProvider: " + account.getClass().getName());
-        AuthAccountProvider authAccountProvider = (AuthAccountProvider) account;
-        AuthAccount authAccount = authAccountProvider.getAuthAccount();
+        AuthAccount authAccount = new AccountAdapter(account);
 
         return DEFAULT_EXCEPTION_CATCHER.execute(() -> {
             Optional<AuthAccount> foundAccount = queryFirstAccountPlayerId(authAccount.getPlayerId());

--- a/core/src/main/java/me/mastercapexd/auth/database/model/AccountLink.java
+++ b/core/src/main/java/me/mastercapexd/auth/database/model/AccountLink.java
@@ -1,11 +1,14 @@
 package me.mastercapexd.auth.database.model;
 
+import java.util.Objects;
+
 import com.j256.ormlite.field.DataType;
 import com.j256.ormlite.field.DatabaseField;
 import com.j256.ormlite.table.DatabaseTable;
 
 @DatabaseTable(tableName = "auth_links")
 public class AccountLink {
+
     public static final String LINK_TYPE_FIELD_KEY = "link_type";
     public static final String LINK_USER_ID_FIELD_KEY = "link_user_id";
     public static final String LINK_ENABLED_FIELD_KEY = "link_enabled";
@@ -43,6 +46,10 @@ public class AccountLink {
         return id;
     }
 
+    public void setId(long id) {
+        this.id = id;
+    }
+
     public String getLinkType() {
         return linkType;
     }
@@ -59,11 +66,20 @@ public class AccountLink {
         return account;
     }
 
-    public void setLinkUserId(String linkUserId) {
-        this.linkUserId = linkUserId;
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof AccountLink))
+            return false;
+        AccountLink that = (AccountLink) o;
+        return getId() == that.getId() && isLinkEnabled() == that.isLinkEnabled() && Objects.equals(getLinkType(), that.getLinkType()) &&
+                Objects.equals(getLinkUserId(), that.getLinkUserId()) && getAccount().getId() == that.getAccount().getId();
     }
 
-    public void setLinkEnabled(boolean linkEnabled) {
-        this.linkEnabled = linkEnabled;
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId(), getLinkType(), getLinkUserId(), isLinkEnabled(), getAccount().getId());
     }
+
 }

--- a/core/src/main/java/me/mastercapexd/auth/database/model/AuthAccount.java
+++ b/core/src/main/java/me/mastercapexd/auth/database/model/AuthAccount.java
@@ -70,6 +70,20 @@ public class AuthAccount {
         this.lastSessionStartTimestamp = lastSessionStartTimestamp;
     }
 
+    public AuthAccount(long id, String playerId, IdentifierType playerIdType, CryptoProvider cryptoProvider, String lastIp, UUID uniqueId, String playerName,
+                       String passwordHash, long lastQuitTimestamp, long lastSessionStartTimestamp) {
+        this.id = id;
+        this.playerId = playerId;
+        this.playerIdType = playerIdType;
+        this.cryptoProvider = cryptoProvider;
+        this.lastIp = lastIp;
+        this.uniqueId = uniqueId;
+        this.playerName = playerName;
+        this.passwordHash = passwordHash;
+        this.lastQuitTimestamp = lastQuitTimestamp;
+        this.lastSessionStartTimestamp = lastSessionStartTimestamp;
+    }
+
     public long getId() {
         return id;
     }

--- a/core/src/main/java/me/mastercapexd/auth/database/model/AuthAccountProvider.java
+++ b/core/src/main/java/me/mastercapexd/auth/database/model/AuthAccountProvider.java
@@ -1,5 +1,0 @@
-package me.mastercapexd.auth.database.model;
-
-public interface AuthAccountProvider {
-    AuthAccount getAuthAccount();
-}


### PR DESCRIPTION
### Changes

- [X] Internal code
- [X] API (affecting end-user code) 
- [ ] Other

### Description
This pull request aims to replace dirty hacks like `AuthAccountProvider`, which leads to confusion in the future.

Partially makes it easier to implement migration from other plugins, because now it doesn't require `AuthAccountProvider`.