### PR TITLE
[Fix] Replace `mvn.bivashy.dev` repository with maven central, snapshot rep…

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -13,6 +13,10 @@
 
     <repositories>
         <repository>
+            <id>maven-snapshots</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+        </repository>
+        <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
@@ -89,7 +93,7 @@
 
         <!-- Libby runtime dependency management -->
         <dependency>
-            <groupId>com.github.bivashy.libby</groupId>
+            <groupId>com.alessiodp.libby</groupId>
             <artifactId>libby-core</artifactId>
         </dependency>
     </dependencies>

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -71,7 +71,7 @@
 
         <!-- Libby -->
         <dependency>
-            <groupId>com.github.bivashy.libby</groupId>
+            <groupId>com.alessiodp.libby</groupId>
             <artifactId>libby-bungee</artifactId>
         </dependency>
     </dependencies>

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -12,6 +12,11 @@
 
     <repositories>
         <repository>
+            <id>maven-snapshots</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+        </repository>
+
+        <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>

--- a/pom.xml
+++ b/pom.xml
@@ -57,13 +57,13 @@
         <bungeecord.version>1.20-R0.1</bungeecord.version>
 
         <velocity-api.version>3.1.1</velocity-api.version>
-        <velocity-proxy.version>3.2.0-SNAPSHOT</velocity-proxy.version>
+        <velocity-proxy.version>3.3.0-3554abc</velocity-proxy.version>
 
         <auth-api.version>${project.version}</auth-api.version>
         <ormlite.version>6.1</ormlite.version>
         <multimessenger.version>1.0.5</multimessenger.version>
         <event-bus.version>1.3</event-bus.version>
-        <libby.version>2.0.0</libby.version>
+        <libby.version>2.0.0-SNAPSHOT</libby.version>
         <nanolimbo.version>1.0.8</nanolimbo.version>
 
         <!-- Maven plugins -->
@@ -266,17 +266,17 @@
 
             <!-- Libby -->
             <dependency>
-                <groupId>com.github.bivashy.libby</groupId>
+                <groupId>com.alessiodp.libby</groupId>
                 <artifactId>libby-core</artifactId>
                 <version>${libby.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.bivashy.libby</groupId>
+                <groupId>com.alessiodp.libby</groupId>
                 <artifactId>libby-bungee</artifactId>
                 <version>${libby.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.bivashy.libby</groupId>
+                <groupId>com.alessiodp.libby</groupId>
                 <artifactId>libby-velocity</artifactId>
                 <version>${libby.version}</version>
             </dependency>
@@ -295,7 +295,7 @@
                 <version>${velocity-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.velocitypowered</groupId>
+                <groupId>io.github.bivashy</groupId>
                 <artifactId>velocity-proxy</artifactId>
                 <version>${velocity-proxy.version}</version>
             </dependency>
@@ -376,7 +376,7 @@
                             </excludes>
                         </filter>
                         <filter>
-                            <artifact>com.github.bivashy.libby:libby-core</artifact>
+                            <artifact>com.alessiodp.libby:libby-core</artifact>
                             <includes>
                                 <include>com/alessiodp/libby/**</include>
                             </includes>

--- a/velocity/pom.xml
+++ b/velocity/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>velocity</artifactId>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
     </properties>
 
     <repositories>

--- a/velocity/pom.xml
+++ b/velocity/pom.xml
@@ -24,11 +24,6 @@
             <id>papermc</id>
             <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
-
-        <repository>
-            <id>bivashy</id>
-            <url>https://mvn.bivashy.dev/snapshots/</url>
-        </repository>
     </repositories>
 
     <dependencies>
@@ -73,7 +68,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.velocitypowered</groupId>
+            <groupId>io.github.bivashy</groupId>
             <artifactId>velocity-proxy</artifactId>
             <scope>provided</scope>
         </dependency>
@@ -87,7 +82,7 @@
 
         <!-- Libby -->
         <dependency>
-            <groupId>com.github.bivashy.libby</groupId>
+            <groupId>com.alessiodp.libby</groupId>
             <artifactId>libby-velocity</artifactId>
         </dependency>
 

--- a/velocity/pom.xml
+++ b/velocity/pom.xml
@@ -16,6 +16,11 @@
 
     <repositories>
         <repository>
+            <id>maven-snapshots</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+        </repository>
+
+        <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>


### PR DESCRIPTION
## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.

### Changes

- [ ] Internal code
- [ ] API (affecting end-user code)
- [X] Other: Maven

Closes Issue: 
  - #179

## Description

This Pull Request moves `velocity-proxy`, and `libby` dependencies into maven central/snapshot instead of using self-host maven repository 
