### PR TITLE
[CI/CD] Bump GitHub Actions Java version to 17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven


### PR DESCRIPTION
## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.

### Changes

- [ ] Internal code
- [ ] API (affecting end-user code)
- [X] Other: CI/CD

Closes Issue:
  - #182

## Description

This Pull Request uses 17 temurin Java instead of Java 11.
