### PR TITLE
[CI/CD] Declare Java 17 usage in codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,6 +46,13 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2


### PR DESCRIPTION
## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.

### Changes

- [ ] Internal code
- [ ] API (affecting end-user code)
- [X] Other: CI/CD (GitHub Actions)

Closes Issue: 
  - #184 

## Description

This Pull Request uses Java 17 in CodeQL instead of default Java (11)
