### PR TITLE
[Fix] Ignore ApiMessagesDenySendException in VK link

### DIFF
--- a/core/src/main/java/me/mastercapexd/auth/vk/command/VKCommandRegistry.java
+++ b/core/src/main/java/me/mastercapexd/auth/vk/command/VKCommandRegistry.java
@@ -12,6 +12,7 @@ import me.mastercapexd.auth.link.vk.VKLinkType;
 import me.mastercapexd.auth.messenger.commands.MessengerCommandRegistry;
 import me.mastercapexd.auth.shared.commands.MessengerLinkCommandTemplate;
 import me.mastercapexd.auth.shared.commands.VKLinkCommand;
+import me.mastercapexd.auth.vk.command.exception.VKExceptionHandler;
 import revxrsal.commands.CommandHandler;
 
 public class VKCommandRegistry extends MessengerCommandRegistry {
@@ -21,6 +22,7 @@ public class VKCommandRegistry extends MessengerCommandRegistry {
     public VKCommandRegistry() {
         super(COMMAND_HANDLER, VKLinkType.getInstance());
         COMMAND_HANDLER.registerContextResolver(LinkCommandActorWrapper.class, context -> new VKCommandActorWrapper(context.actor()));
+        COMMAND_HANDLER.setExceptionHandler(new VKExceptionHandler(VKLinkType.getInstance()));
         registerCommands();
 
         try {

--- a/core/src/main/java/me/mastercapexd/auth/vk/command/exception/VKExceptionHandler.java
+++ b/core/src/main/java/me/mastercapexd/auth/vk/command/exception/VKExceptionHandler.java
@@ -1,0 +1,21 @@
+package me.mastercapexd.auth.vk.command.exception;
+
+import com.bivashy.auth.api.link.LinkType;
+import com.vk.api.sdk.exceptions.ApiMessagesDenySendException;
+import me.mastercapexd.auth.messenger.commands.exception.MessengerExceptionHandler;
+import revxrsal.commands.command.CommandActor;
+
+public class VKExceptionHandler extends MessengerExceptionHandler {
+
+    public VKExceptionHandler(LinkType linkType) {
+        super(linkType);
+    }
+
+    @Override
+    public void onUnhandledException(CommandActor actor, Throwable throwable) {
+        if (throwable instanceof ApiMessagesDenySendException)
+            return;
+        super.onUnhandledException(actor, throwable);
+    }
+
+}


### PR DESCRIPTION
## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] API (affecting end-user code)
- [ ] Other: _

Closes Issue:
  - #195

## Description

This Pull Request prevents exception recursion by ignoring `ApiMessagesDenySendException`.
